### PR TITLE
Some fixes to Groups

### DIFF
--- a/AdobeUMInterface.psm1
+++ b/AdobeUMInterface.psm1
@@ -977,6 +977,9 @@ function New-SyncADGroupRequest
         $Members += $ADBMembers.email | ForEach-Object {$_.ToLower()}
     }
 
+    #Grab all Adobe Users 
+    $AdobeUsers = Get-AdobeUsers -ClientInformation $ClientInformation
+
     #Results
     $Request = @()
 
@@ -986,9 +989,17 @@ function New-SyncADGroupRequest
         #If adobe group does not contain ad user
         if ($Members.Length -le 0 -or -not $Members.Contains($ADUser.mail.ToLower()))
         {
-            $AddToGroup = New-GroupUserAddAction -Groups $AdobeGroupName
-            #Need to add
-            $Request += New-CreateUserRequest -FirstName $ADUser.GivenName -LastName $ADUser.SurName -Email $ADUser.mail.ToLower() -Country "US" -AdditionalActions $AddToGroup
+            #Check if user already exists
+            if ($AdobeUsers.email -contains $ADUser.mail.ToLower()) 
+            {
+                $Request += New-AddToGroupRequest -User $ADUser.mail.ToLower() -Groups $AdobeGroupName
+            }
+            else 
+            {
+                $AddToGroup = New-GroupUserAddAction -Groups $AdobeGroupName
+                #Need to add
+                $Request += New-CreateUserRequest -FirstName $ADUser.GivenName -LastName $ADUser.SurName -Email $ADUser.mail.ToLower() -Country "US" -AdditionalActions $AddToGroup
+            }
         }
     }
     #Find excess members and create requests to remove them

--- a/AdobeUMInterface.psm1
+++ b/AdobeUMInterface.psm1
@@ -867,8 +867,8 @@ function New-AddToGroupRequest
         [Parameter(Mandatory=$true)][string]$User, 
         [Parameter(Mandatory=$true)]$Groups
     )
-    $GroupAddAction = New-GroupUserAddAction -GroupNames $Groups
-    return return (New-Object -TypeName PSObject -Property @{user=$User;do=@()+$GroupAddAction})
+    $GroupAddAction = New-GroupUserAddAction -Groups $Groups
+    return (New-Object -TypeName PSObject -Property @{user=$User;do=@()+$GroupAddAction})
 }
 
 <#

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A complete example of the calls you should make after step 5 are below. This scr
 
 ```powershell
 #Load the Auth cert generated with New-Cert
-$SignatureCert = Load-PFXCert -Password "MyPassword" -CertPath "C:\Certs\AdobeAuthPrivate.pfx"
+$SignatureCert = Import-PFXCert -Password "MyPassword" -CertPath "C:\Certs\AdobeAuthPrivate.pfx"
 
 #Client info from https://console.adobe.io/
 $ClientInformation = New-ClientInformation -APIKey "1234123412341234" -OrganizationID "1234123412341234@AdobeOrg" -ClientSecret "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx" `


### PR DESCRIPTION
- Fix wrong parameter
- Fix wrong return statement
- Checks if user already exists and add only to group, because `ignoreIfAlreadyExists` doesn't work well on Adobe's API