### PR TITLE
Add param guard for empty request

### DIFF
--- a/AdobeUMInterface.psm1
+++ b/AdobeUMInterface.psm1
@@ -1024,6 +1024,7 @@ function Send-UserManagementRequest
     (
         [ValidateScript({$_.Token -ne $null})]
         [Parameter(Mandatory=$true)]$ClientInformation,
+        [ValidateScript({$_ -ne $null})]
         $Requests
     )
     #Ensure is array


### PR DESCRIPTION
- You will get an odd error if the request is empty when using Send-UserManagementRequest
- This should give a better error message when running the scripts